### PR TITLE
chore: cors 설정 제거

### DIFF
--- a/backend/transaction-service/src/main/java/com/sodam/transactionservice/application/api/controller/TransactionController.java
+++ b/backend/transaction-service/src/main/java/com/sodam/transactionservice/application/api/controller/TransactionController.java
@@ -14,11 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-@CrossOrigin(origins = {
-        "http://localhost:5173",
-        "https://sodam-nine.vercel.app",
-        "http://127.0.0.1:5173"
-})
 @RestController
 @RequestMapping("/api/transactions")
 @RequiredArgsConstructor


### PR DESCRIPTION
게이트웨이 서비스에서 CORS 설정을 하기 때문에, CORS 중복 오류가 발생하여 거래 서비스에서 CORS 설정을 제거합니다.