### PR TITLE
fix: 메인 영역의 최대 너비 설정 제거

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,6 @@ function App() {
         </Toolbar>
       </AppBar>
       <Box
-        maxWidth="md"
         sx={{
           flexGrow: 1,
           mt: 4,


### PR DESCRIPTION
메인 영역의 최대 너비 설정을 제거하여, 전체 화면을 사용할 수 있게합니다.