### PR TITLE
화면에 따른 차트 정렬 재배치

### DIFF
--- a/frontend/src/features/transaction/TransactionPage.tsx
+++ b/frontend/src/features/transaction/TransactionPage.tsx
@@ -133,7 +133,7 @@ function TransactionPage() {
       </Box>
 
       <Box>
-        <Box display={"flex"} flexDirection={"row"} alignItems={"center"} justifyContent={"center"} gap={10} paddingBottom={5}>
+        <Box display={"flex"} flexDirection={{ xs: "column", sm: "row" }} alignItems={"center"} justifyContent={"center"} gap={10} paddingBottom={5}>
           <Box>
             <Typography variant="h5" component="h2" mb={2}>
               수입


### PR DESCRIPTION
모바일 화면에서 수평 스크롤 방지를 위해 차트 정렬을 수직으로 변경합니다.