### PR TITLE
로고 클릭 시 대시보드 페이지 이동

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -68,7 +68,7 @@ function HeaderComponent({ openSide, toggleDrawer }: HeaderProps) {
         <Typography
           variant="h6"
           component="div"
-          sx={{ flexGrow: 1 }}
+          sx={{ flexGrow: 1, cursor: "pointer" }}
           onClick={handleLogoClick}
         >
           💰 소담

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Toolbar, Typography, styled } from "@mui/material";
+import { IconButton, Toolbar, Typography, styled, Box } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import MuiAppBar, {
   type AppBarProps as MuiAppBarProps,
@@ -65,13 +65,14 @@ function HeaderComponent({ openSide, toggleDrawer }: HeaderProps) {
         >
           <MenuIcon />
         </IconButton>
-        <Typography
-          variant="h6"
-          component="div"
-          sx={{ flexGrow: 1, cursor: "pointer" }}
-          onClick={handleLogoClick}
-        >
-          💰 소담
+        <Typography variant="h6" component="div">
+          <Box
+            component="span"
+            sx={{ cursor: "pointer", display: "inline-block" }}
+            onClick={handleLogoClick}
+          >
+            💰 소담
+          </Box>
         </Typography>
       </Toolbar>
     </StyledAppBar>

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -6,6 +6,7 @@ import MuiAppBar, {
 import { memo } from "react";
 import { DRAWER_WIDTH } from "../../constants/layout";
 import { useIsDesktop } from "../../hooks/useIsDesktop";
+import { useNavigate } from "react-router-dom";
 
 interface AppBarProps extends MuiAppBarProps {
   open?: boolean;
@@ -41,6 +42,12 @@ const StyledAppBar = styled(MuiAppBar, {
 function HeaderComponent({ openSide, toggleDrawer }: HeaderProps) {
   const isDesktop = useIsDesktop(); // sm 이상이면 데스크탑
 
+  const nav = useNavigate();
+
+  const handleLogoClick = () => {
+    void nav("/dashboard");
+  };
+
   return (
     <StyledAppBar position="relative" open={openSide} isDesktop={isDesktop}>
       <Toolbar>
@@ -58,7 +65,12 @@ function HeaderComponent({ openSide, toggleDrawer }: HeaderProps) {
         >
           <MenuIcon />
         </IconButton>
-        <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+        <Typography
+          variant="h6"
+          component="div"
+          sx={{ flexGrow: 1 }}
+          onClick={handleLogoClick}
+        >
           💰 소담
         </Typography>
       </Toolbar>


### PR DESCRIPTION
로고를 버튼 취급하도록 하고, 클릭 시 대시보드 페이지로 이동할 수 있습니다.