### PR TITLE
feat: internal API 및 gateway 인증 정책 강화

### DIFF
--- a/backend/common-module/src/main/java/com/sodam/common/config/CommonDefaultsEnvironmentPostProcessor.java
+++ b/backend/common-module/src/main/java/com/sodam/common/config/CommonDefaultsEnvironmentPostProcessor.java
@@ -28,7 +28,6 @@ public class CommonDefaultsEnvironmentPostProcessor implements EnvironmentPostPr
         putIfMissing(environment, defaults, "sodam.feign.retry.max-period-ms", "1000");
         putIfMissing(environment, defaults, "sodam.feign.retry.max-attempts", isProdProfile(environment) ? "1" : "2");
         putIfMissing(environment, defaults, "sodam.feign.logger-level", isVerboseProfile(environment) ? "FULL" : "BASIC");
-        putIfMissing(environment, defaults, "internal.service.token", InternalServiceProperties.DEFAULT_TOKEN);
         putIfMissing(environment, defaults, "management.tracing.sampling.probability", isVerboseProfile(environment) ? "1.0" : "0.1");
 
         if (!defaults.isEmpty()) {

--- a/backend/common-module/src/main/java/com/sodam/common/config/CommonInternalServiceAutoConfiguration.java
+++ b/backend/common-module/src/main/java/com/sodam/common/config/CommonInternalServiceAutoConfiguration.java
@@ -22,7 +22,7 @@ public class CommonInternalServiceAutoConfiguration {
             ObjectMapper objectMapper
     ) {
         FilterRegistrationBean<InternalRequestFilter> registrationBean = new FilterRegistrationBean<>();
-        registrationBean.setFilter(new InternalRequestFilter(properties.tokenOrDefault(), objectMapper));
+        registrationBean.setFilter(new InternalRequestFilter(properties.token(), objectMapper));
         registrationBean.addUrlPatterns("/internal/*");
         registrationBean.setOrder(Ordered.HIGHEST_PRECEDENCE);
         return registrationBean;

--- a/backend/common-module/src/main/java/com/sodam/common/config/FeignConfig.java
+++ b/backend/common-module/src/main/java/com/sodam/common/config/FeignConfig.java
@@ -58,6 +58,6 @@ public class FeignConfig {
     @Bean
     RequestInterceptor internalServiceFeignInterceptor(Environment environment, InternalServiceProperties properties) {
         String applicationName = environment.getProperty("spring.application.name", "unknown-service");
-        return new InternalServiceFeignInterceptor(applicationName, properties.tokenOrDefault());
+        return new InternalServiceFeignInterceptor(applicationName, properties.token());
     }
 }

--- a/backend/common-module/src/main/java/com/sodam/common/config/InternalServiceProperties.java
+++ b/backend/common-module/src/main/java/com/sodam/common/config/InternalServiceProperties.java
@@ -5,9 +5,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "internal.service")
 public record InternalServiceProperties(String token) {
 
-    public static final String DEFAULT_TOKEN = "sodam-internal-token";
-
-    public String tokenOrDefault() {
-        return token == null || token.isBlank() ? DEFAULT_TOKEN : token;
+    public boolean isConfigured() {
+        return token != null && !token.isBlank();
     }
 }

--- a/backend/common-module/src/main/resources/application.yml
+++ b/backend/common-module/src/main/resources/application.yml
@@ -14,7 +14,7 @@ sodam:
 
 internal:
   service:
-    token: ${INTERNAL_SERVICE_TOKEN:sodam-internal-token}
+    token: ${INTERNAL_SERVICE_TOKEN:}
 
 management:
   tracing:

--- a/backend/docs/INTERNAL_API_SECURITY.md
+++ b/backend/docs/INTERNAL_API_SECURITY.md
@@ -1,0 +1,50 @@
+# Internal API Security
+
+## 목적
+
+내부 서비스 간 호출용 `/internal/**` 엔드포인트를 외부 공개 API와 명확히 분리하고,
+Gateway 및 서비스 레벨에서 일관된 인증 정책을 적용한다.
+
+## 현재 정책
+
+- 외부 공개 API는 `/api/**` 경로만 사용한다.
+- 내부 서비스 전용 API는 `/internal/**` 경로만 사용한다.
+- Gateway는 `/internal/**` 경로를 외부로 라우팅하지 않고 `404`로 차단한다.
+- `/internal/**` 요청은 `common-module`의 `InternalRequestFilter`에서 검증한다.
+- 내부 호출은 Feign + `InternalServiceFeignInterceptor`로만 수행한다.
+
+## 필수 헤더
+
+- `X-Internal-Service`
+  - 호출 서비스 이름
+- `X-Internal-Token`
+  - 환경변수 `INTERNAL_SERVICE_TOKEN`에서 주입된 공통 내부 토큰
+- `X-Correlation-Id`
+  - 선택 헤더
+  - 추적 편의를 위해 전달
+
+## 환경 변수
+
+- `INTERNAL_SERVICE_TOKEN`은 모든 백엔드 서비스에서 동일한 값으로 설정해야 한다.
+- 기본값 fallback은 사용하지 않는다.
+- 로컬, Docker, 운영 환경 모두 배포 시점에 명시적으로 주입한다.
+
+## Gateway 정책
+
+- 인증이 필요한 `/api/**` 경로는 Gateway에서 JWT를 검사한다.
+- 인증 실패 응답은 공통 JSON 형식으로 반환한다.
+- `/internal/**`는 Gateway를 통해 접근할 수 없다.
+
+## 서비스 정책
+
+- `/internal/**`는 Spring Security permit 대상이어도, 실제 접근은 `InternalRequestFilter`가 차단한다.
+- 내부 API는 프론트엔드에서 직접 호출하지 않는다.
+- 서비스 간 직접 호출은 Feign 클라이언트로만 구현한다.
+
+## 운영 체크리스트
+
+1. 모든 서비스에 `INTERNAL_SERVICE_TOKEN`이 동일하게 설정되어 있는지 확인한다.
+2. Gateway 외부 노출 대상에 개별 서비스 포트를 포함하지 않는다.
+3. 신규 내부 API는 `/internal/**` 아래에만 추가한다.
+4. 신규 Feign 클라이언트가 공통 interceptor를 사용하도록 유지한다.
+5. `/internal/**` 경로를 Gateway 라우트에 추가하지 않는다.

--- a/backend/gateway-service/src/main/java/com/sodam/gatewayservice/config/RouteConfig.java
+++ b/backend/gateway-service/src/main/java/com/sodam/gatewayservice/config/RouteConfig.java
@@ -6,6 +6,7 @@ import org.springframework.cloud.gateway.route.RouteLocator;
 import org.springframework.cloud.gateway.route.builder.RouteLocatorBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
 
 @Configuration
 @RequiredArgsConstructor
@@ -16,6 +17,9 @@ public class RouteConfig {
     @Bean
     public RouteLocator customRouteLocator(RouteLocatorBuilder builder) {
         return builder.routes()
+                .route("internal-api-block", r -> r.path("/internal/**")
+                        .filters(f -> f.setStatus(HttpStatus.NOT_FOUND))
+                        .uri("no://op"))
                 .route("user-service-no-filter", r -> r.path("/api/auth/login", "/api/auth/logout", "/api/auth/register", "/oauth2/authorization/**", "/login/oauth2/**", "/api/auth/reissue")
                         .uri("lb://user-service"))
                 .route("user-service-with-filter", r -> r.path("/api/auth/**")

--- a/backend/gateway-service/src/main/java/com/sodam/gatewayservice/filter/JwtAuthGatewayFilter.java
+++ b/backend/gateway-service/src/main/java/com/sodam/gatewayservice/filter/JwtAuthGatewayFilter.java
@@ -1,17 +1,24 @@
 package com.sodam.gatewayservice.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sodam.common.response.ApiResponse;
+import com.sodam.common.response.ResponseCode;
 import com.sodam.common.security.HeaderNames;
 import com.sodam.gatewayservice.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilter;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
+
+import java.nio.charset.StandardCharsets;
 
 @Component
 @RequiredArgsConstructor
@@ -19,6 +26,7 @@ import reactor.core.publisher.Mono;
 public class JwtAuthGatewayFilter implements GatewayFilter {
 
     private final JwtUtil jwtUtil;
+    private final ObjectMapper objectMapper;
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
@@ -26,24 +34,41 @@ public class JwtAuthGatewayFilter implements GatewayFilter {
 
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
             log.error("JWT 토큰 정보가 존재하지 않습니다.");
-            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-            return exchange.getResponse().setComplete();
+            return writeErrorResponse(exchange, ResponseCode.UNAUTHORIZED, "인증 토큰이 없습니다.");
         }
 
         String token = authHeader.substring(7);
 
         if (!jwtUtil.validateToken(token)) {
             log.error("JWT 토큰 검증에 실패했습니다.");
-            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-            return exchange.getResponse().setComplete();
+            return writeErrorResponse(exchange, ResponseCode.UNAUTHORIZED, "유효하지 않은 인증 토큰입니다.");
         }
 
         String email = jwtUtil.getUserEmail(token);
         log.debug("JWT 토큰 검증 결과 사용자 이메일 정보 : {}", email);
+
         ServerHttpRequest request = exchange.getRequest().mutate()
                 .header(HeaderNames.USER_EMAIL, String.valueOf(email))
                 .build();
 
         return chain.filter(exchange.mutate().request(request).build());
+    }
+
+    private Mono<Void> writeErrorResponse(ServerWebExchange exchange, ResponseCode code, String message) {
+        try {
+            byte[] body = objectMapper.writeValueAsBytes(ApiResponse.fail(code.getCode(), message));
+            exchange.getResponse().setStatusCode(HttpStatus.valueOf(code.getStatus()));
+            exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            DataBuffer buffer = exchange.getResponse().bufferFactory().wrap(body);
+            return exchange.getResponse().writeWith(Mono.just(buffer));
+        } catch (Exception e) {
+            log.error("Gateway 인증 실패 응답 작성 중 오류가 발생했습니다.", e);
+            exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+            exchange.getResponse().getHeaders().setContentType(MediaType.APPLICATION_JSON);
+            DataBuffer fallback = exchange.getResponse().bufferFactory()
+                    .wrap("{\"code\":\"E-00002\",\"message\":\"인증 처리 중 오류가 발생했습니다.\",\"data\":null}"
+                            .getBytes(StandardCharsets.UTF_8));
+            return exchange.getResponse().writeWith(Mono.just(fallback));
+        }
     }
 }

--- a/backend/infra/.env.example
+++ b/backend/infra/.env.example
@@ -3,6 +3,7 @@ MYSQL_DATABASE=sodam
 DB_USERNAME=sodam
 DB_PASSWORD=change-me
 JWT_SECRET=change-me-to-a-long-random-string
+INTERNAL_SERVICE_TOKEN=change-me-to-a-shared-internal-token
 GOOGLE_CLIENT_ID=change-me
 GOOGLE_CLIENT_SECRET=change-me
 GOOGLE_REDIRECT_URI=https://junguk7880.site/login/oauth2/code/google


### PR DESCRIPTION
Gateway의 인증 실패 응답을 공통 형식으로 정리하고 /internal 경로 차단, 내부 서비스 토큰 기본값 제거 및 문서화를 반영한다.