### PR TITLE
refactor: 하드코딩된 설정값 및 매직 넘버 정리

### DIFF
--- a/backend/common-module/src/main/java/com/sodam/common/config/CommonWebMvcAutoConfiguration.java
+++ b/backend/common-module/src/main/java/com/sodam/common/config/CommonWebMvcAutoConfiguration.java
@@ -17,11 +17,15 @@ import java.util.List;
 @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)
 public class CommonWebMvcAutoConfiguration implements WebMvcConfigurer {
 
+    private static final int DEFAULT_PAGE_INDEX = 0;
+    private static final int DEFAULT_PAGE_SIZE = 20;
+    private static final int MAX_PAGE_SIZE = 100;
+
     @Bean
     public PageableHandlerMethodArgumentResolverCustomizer pageableCustomizer() {
         return resolver -> {
-            resolver.setFallbackPageable(PageRequest.of(0, 20));
-            resolver.setMaxPageSize(100);
+            resolver.setFallbackPageable(PageRequest.of(DEFAULT_PAGE_INDEX, DEFAULT_PAGE_SIZE));
+            resolver.setMaxPageSize(MAX_PAGE_SIZE);
             resolver.setOneIndexedParameters(false);
             resolver.setPageParameterName("page");
             resolver.setSizeParameterName("size");

--- a/frontend/src/entities/category/api/categoryApi.ts
+++ b/frontend/src/entities/category/api/categoryApi.ts
@@ -1,4 +1,8 @@
 import api from "../../../shared/api/api";
+import {
+  CATEGORY_SELECTION_PAGE_SIZE,
+  DEFAULT_PAGE_INDEX,
+} from "../../../shared/config/app";
 import type {
   CategoryListItemResponse,
   CategoryListResponse,
@@ -14,8 +18,8 @@ interface CategoryUpsertRequest {
 
 const categoryApi = {
   getCategories: async (
-    page = 0,
-    size = 100,
+    page = DEFAULT_PAGE_INDEX,
+    size = CATEGORY_SELECTION_PAGE_SIZE,
   ): Promise<CategoryListResponse> =>
     api.get<CategoryListResponse>(
       `${CATEGORY_BASE_URL}?page=${page}&size=${size}`,

--- a/frontend/src/entities/category/model/useCategories.ts
+++ b/frontend/src/entities/category/model/useCategories.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useState } from "react";
 import categoryApi from "../api/categoryApi";
 import type { CategoryListResponse } from "../../transaction/api/category.types";
 import { useAccountBookContext } from "../../accountbook/model/AccountBookContext";
+import {
+  DEFAULT_CATEGORY_PAGE_SIZE,
+  DEFAULT_PAGE_INDEX,
+} from "../../../shared/config/app";
 import { getServerErrorMessage } from "../../../shared/lib/serverState";
 
 export const useCategories = () => {
@@ -22,7 +26,10 @@ export const useCategories = () => {
     setError(null);
 
     try {
-      const response = await categoryApi.getCategories(0, 20);
+      const response = await categoryApi.getCategories(
+        DEFAULT_PAGE_INDEX,
+        DEFAULT_CATEGORY_PAGE_SIZE,
+      );
       setCategories(response);
     } catch (nextError) {
       setError(

--- a/frontend/src/features/transaction/ui/TransactionCreateModal.tsx
+++ b/frontend/src/features/transaction/ui/TransactionCreateModal.tsx
@@ -26,6 +26,10 @@ import type { ClassificationResponse } from "../../../entities/category/api/clas
 import type { CategoryListItemResponse } from "../../../entities/transaction/api/category.types";
 import transactionApi from "../../../entities/transaction/api/transactionApi";
 import type { TransactionCreateRequestDto } from "../../../entities/transaction/api/transaction.types";
+import {
+  CATEGORY_SELECTION_PAGE_SIZE,
+  DEFAULT_PAGE_INDEX,
+} from "../../../shared/config/app";
 
 const style = {
   position: "absolute",
@@ -95,7 +99,10 @@ const TransactionCreateModal: React.FC<TransactionCreateModalProps> = ({
       try {
         const [fetchedClassifications, fetchedCategories] = await Promise.all([
           classificationApi.getClassifications(currentAccountBook.id),
-          categoryApi.getCategories(0, 100),
+          categoryApi.getCategories(
+            DEFAULT_PAGE_INDEX,
+            CATEGORY_SELECTION_PAGE_SIZE,
+          ),
         ]);
 
         setClassifications(fetchedClassifications);

--- a/frontend/src/features/transaction/ui/TransactionEditModal.tsx
+++ b/frontend/src/features/transaction/ui/TransactionEditModal.tsx
@@ -26,6 +26,10 @@ import type {
   TransactionUpdateRequestDto,
 } from "../../../entities/transaction/api/transaction.types";
 import { useAccountBookContext } from "../../../entities/accountbook/model/AccountBookContext";
+import {
+  CATEGORY_SELECTION_PAGE_SIZE,
+  DEFAULT_PAGE_INDEX,
+} from "../../../shared/config/app";
 
 const style = {
   position: "absolute" as const,
@@ -93,7 +97,10 @@ const TransactionEditModal: React.FC<TransactionEditModalProps> = ({
       }
 
       try {
-        const fetchedCategories = await categoryApi.getCategories(0, 100);
+        const fetchedCategories = await categoryApi.getCategories(
+          DEFAULT_PAGE_INDEX,
+          CATEGORY_SELECTION_PAGE_SIZE,
+        );
         setCategories(fetchedCategories.categories ?? []);
       } catch (nextError) {
         if (axios.isAxiosError(nextError)) {

--- a/frontend/src/pages/login/ui/LoginPage.tsx
+++ b/frontend/src/pages/login/ui/LoginPage.tsx
@@ -15,6 +15,7 @@ import {
 import { alpha, useTheme } from "@mui/material/styles";
 import LoginApi from "../../../features/auth/api/LoginApi";
 import { restoreSession, setAccessToken } from "../../../shared/api/api";
+import { OAUTH_AUTHORIZATION_URLS } from "../../../shared/config/app";
 import { useAccountBookContext } from "../../../entities/accountbook/model/AccountBookContext";
 
 function LoginPage() {
@@ -58,11 +59,11 @@ function LoginPage() {
   };
 
   const handleKakaoLoginBtn = () => {
-    window.location.href = "https://junguk7880.site/oauth2/authorization/kakao";
+    window.location.href = OAUTH_AUTHORIZATION_URLS.kakao;
   };
 
   const handleGoogleLoginBtn = () => {
-    window.location.href = "https://junguk7880.site/oauth2/authorization/google";
+    window.location.href = OAUTH_AUTHORIZATION_URLS.google;
   };
 
   useEffect(() => {

--- a/frontend/src/shared/api/api.ts
+++ b/frontend/src/shared/api/api.ts
@@ -5,9 +5,9 @@ import axios, {
   type AxiosResponse,
   type InternalAxiosRequestConfig,
 } from "axios";
+import { API_BASE_URL } from "../config/app";
 
-const BASE_URL =
-  import.meta.env.VITE_API_TRANSACTION_BASE_URL ?? "http://localhost:10003/api";
+const BASE_URL = API_BASE_URL;
 
 export interface ApiResponse<T> {
   code: string;

--- a/frontend/src/shared/config/app.ts
+++ b/frontend/src/shared/config/app.ts
@@ -1,0 +1,14 @@
+export const DEFAULT_PAGE_INDEX = 0;
+export const DEFAULT_CATEGORY_PAGE_SIZE = 20;
+export const CATEGORY_SELECTION_PAGE_SIZE = 100;
+
+export const API_BASE_URL =
+  import.meta.env.VITE_API_TRANSACTION_BASE_URL ?? "http://localhost:10003/api";
+
+const AUTH_BASE_URL =
+  import.meta.env.VITE_AUTH_BASE_URL ?? "https://junguk7880.site";
+
+export const OAUTH_AUTHORIZATION_URLS = {
+  kakao: `${AUTH_BASE_URL}/oauth2/authorization/kakao`,
+  google: `${AUTH_BASE_URL}/oauth2/authorization/google`,
+} as const;


### PR DESCRIPTION
OAuth URL, API fallback 주소, 카테고리 조회 페이지 크기, 공통 페이지네이션 기본값을 설정과 상수로 분리해 변경 포인트를 한 곳에서 관리하도록 정리합니다.